### PR TITLE
Fixed Xcode regeneration bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.1] 2017-11-17
+
+### Fixed
+- Xcode regeneration bar does not run if the xcode flag was not passed in.
+- Xcode projects are now opened if the xcode flag is passed into a command.
+
 ## [1.9.0] 2017-11-15
 
 ### Added

--- a/Sources/Ether/Install.swift
+++ b/Sources/Ether/Install.swift
@@ -62,7 +62,6 @@ public final class Install: Command {
         let fileManager = FileManager.default
         let name = try value("name", from: arguments)
         let installBar = console.loadingBar(title: "Installing Dependency")
-        let xcodeBar = console.loadingBar(title: "Generating Xcode Project")
         
         // Get package manifest and JSON data
         guard let manifestURL = URL(string: "file:\(fileManager.currentDirectoryPath)/Package.swift") else {
@@ -127,6 +126,7 @@ public final class Install: Command {
         installBar.finish()
         
         if let _ = arguments.options["xcode"] {
+            let xcodeBar = console.loadingBar(title: "Generating Xcode Project")
             xcodeBar.start()
             _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "generate-xcodeproj"])
             xcodeBar.finish()

--- a/Sources/Ether/Install.swift
+++ b/Sources/Ether/Install.swift
@@ -130,6 +130,7 @@ public final class Install: Command {
             xcodeBar.start()
             _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "generate-xcodeproj"])
             xcodeBar.finish()
+            try console.execute(program: "/bin/sh", arguments: ["-c", "open *.xcodeproj"], input: nil, output: nil, error: nil)
         }
         
         console.output("📦  \(newPackageCount) packages installed", style: .plain, newLine: true)

--- a/Sources/Ether/Remove.swift
+++ b/Sources/Ether/Remove.swift
@@ -86,6 +86,7 @@ public final class Remove: Command {
             xcodeBar.start()
             _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "generate-xcodeproj"])
             xcodeBar.finish()
+            try console.execute(program: "/bin/sh", arguments: ["-c", "open *.xcodeproj"], input: nil, output: nil, error: nil)
         }
         
         console.output("📦  \(pinsCount) packages removed", style: .custom(.white), newLine: true)

--- a/Sources/Ether/Remove.swift
+++ b/Sources/Ether/Remove.swift
@@ -48,7 +48,6 @@ public final class Remove: Command {
     
     public func run(arguments: [String]) throws {
         let removingProgressBar = console.loadingBar(title: "Removing Dependency")
-        let xcodeBar = console.loadingBar(title: "Generating Xcode Project")
         removingProgressBar.start()
         
         let manager = FileManager.default
@@ -83,6 +82,7 @@ public final class Remove: Command {
         removingProgressBar.finish()
         
         if let _ = arguments.options["xcode"] {
+            let xcodeBar = console.loadingBar(title: "Generating Xcode Project")
             xcodeBar.start()
             _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "generate-xcodeproj"])
             xcodeBar.finish()

--- a/Sources/Ether/Update.swift
+++ b/Sources/Ether/Update.swift
@@ -71,12 +71,6 @@ public final class Update: Command {
         """
 
         let characterColors: [Character: ConsoleColor] = [
-            "/": .cyan,
-            "=": .cyan,
-            "_": .cyan,
-            "|": .cyan,
-            "\\": .cyan,
-            "~": .green,
             "•": .green
         ]
 

--- a/Sources/Ether/Update.swift
+++ b/Sources/Ether/Update.swift
@@ -28,6 +28,9 @@ public final class Update: Command {
     public let signature: [Argument] = [
         Option(name: "self", short: "s", help: [
             "Updates Ether"
+        ]),
+        Option(name: "xcode", short: "x", help: [
+            "Regenerate and open the Xcode project after update its packages"
         ])
     ]
 
@@ -58,6 +61,14 @@ public final class Update: Command {
             _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "resolve"])
             _ = try console.backgroundExecute(program: "swift", arguments: ["build", "--enable-prefetching"])
             updateBar.finish()
+            
+            if let _ = arguments.options["xcode"] {
+                let xcodeBar = console.loadingBar(title: "Generating Xcode Project")
+                xcodeBar.start()
+                _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "generate-xcodeproj"])
+                xcodeBar.finish()
+                try console.execute(program: "/bin/sh", arguments: ["-c", "open *.xcodeproj"], input: nil, output: nil, error: nil)
+            }
         }
     }
 

--- a/Sources/Ether/VersionLatest.swift
+++ b/Sources/Ether/VersionLatest.swift
@@ -50,7 +50,6 @@ public final class VersionLatest: Command {
     
     public func run(arguments: [String]) throws {
         let updateBar = console.loadingBar(title: "Updating Package Versions")
-        let xcodeBar = console.loadingBar(title: "Generating Xcode Project")
         updateBar.start()
         
         let fileManager = FileManager.default
@@ -79,6 +78,7 @@ public final class VersionLatest: Command {
         updateBar.finish()
         
         if let _ = arguments.options["xcode"] {
+            let xcodeBar = console.loadingBar(title: "Generating Xcode Project")
             xcodeBar.start()
             _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "generate-xcodeproj"])
             xcodeBar.finish()

--- a/Sources/Ether/VersionLatest.swift
+++ b/Sources/Ether/VersionLatest.swift
@@ -82,6 +82,7 @@ public final class VersionLatest: Command {
             xcodeBar.start()
             _ = try console.backgroundExecute(program: "swift", arguments: ["package", "--enable-prefetching", "generate-xcodeproj"])
             xcodeBar.finish()
+            try console.execute(program: "/bin/sh", arguments: ["-c", "open *.xcodeproj"], input: nil, output: nil, error: nil)
         }
     }
 }

--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import Foundation
 import Console
 import Ether
 import libc
@@ -39,6 +40,11 @@ if arguments.count == 2, arguments[1] == "--version" || arguments[1] == "-v" {
     exit(0)
 }
 
+let date = Date()
+let formatter = DateFormatter()
+formatter.dateFormat = "YYYY"
+let currentYear = formatter.string(from: date)
+
 do {
     try terminal.run(executable: executable, commands: [
         Search(console: terminal),
@@ -54,7 +60,7 @@ do {
         ], help: ["For interacting with dependency versions"]),
     ], arguments: Array(iterator),
     help: [
-        "MIT 2017 Caleb Kleveter.",
+        "MIT \(currentYear) Caleb Kleveter.",
         "If you are getting errors, open an issue on GitHub.",
         "If you want to help, submit a PR."
     ])

--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -26,7 +26,7 @@ import Ether
 import libc
 
 // The current version of Ether. This string should be updated with each release.
-let version = "1.9.0"
+let version = "1.9.1"
 var arguments = CommandLine.arguments
 let terminal = Terminal(arguments: arguments)
 var iterator = arguments.makeIterator()

--- a/publish.sh
+++ b/publish.sh
@@ -38,3 +38,4 @@ done
 
 rm -rf macOS-sierra.tar.gz
 rm -rf $PACKAGE_NAME
+rm install


### PR DESCRIPTION
The Xcode regeneration bar now only run if the `xcode` flag is passed in.

Xcode projects are now opened when they are regenerated.